### PR TITLE
Sort fields in ProjectionOperator to ensure deterministic order

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.HashUtil;
@@ -88,8 +89,9 @@ public class ProjectionOperator extends BaseProjectOperator<ProjectionBlock> {
     // SQL statements such as SELECT 'literal' FROM myTable don't have any projection columns.
     if (!_dataSourceMap.keySet().isEmpty()) {
       int count = 0;
-      for (String col : _dataSourceMap.keySet()) {
-        if (count == _dataSourceMap.keySet().size() - 1) {
+      List<String> sortedKeys = _dataSourceMap.keySet().stream().sorted().collect(Collectors.toList());
+      for (String col : sortedKeys) {
+        if (count == sortedKeys.size() - 1) {
           stringBuilder.append(col);
         } else {
           stringBuilder.append(col).append(", ");

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -440,9 +440,9 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
             + "rangeIndexCol3, rawCol1, sortedIndexCol1, textIndexCol1)", 3, 2
     });
     result1.add(new Object[]{
-        "PROJECT(noIndexCol4, rawCol1, sortedIndexCol1, noIndexCol3, mvNoIndexCol1"
-            + ", rangeIndexCol1, rangeIndexCol2, invertedIndexCol1, noIndexCol2, invertedIndexCol2, noIndexCol1, "
-            + "rangeIndexCol3, textIndexCol1, mvRawCol1, jsonIndexCol1, invertedIndexCol3)", 4, 3
+        "PROJECT(invertedIndexCol1, invertedIndexCol2, invertedIndexCol3, jsonIndexCol1, mvNoIndexCol1"
+            + ", mvRawCol1, noIndexCol1, noIndexCol2, noIndexCol3, noIndexCol4, rangeIndexCol1"
+            + ", rangeIndexCol2, rangeIndexCol3, rawCol1, sortedIndexCol1, textIndexCol1)", 4, 3
     });
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
@@ -506,9 +506,9 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
             + "rangeIndexCol3, rawCol1, sortedIndexCol1, textIndexCol1)", 3, 2
     });
     result1.add(new Object[]{
-        "PROJECT(noIndexCol4, rawCol1, sortedIndexCol1, noIndexCol3, mvNoIndexCol1, "
-            + "rangeIndexCol1, rangeIndexCol2, invertedIndexCol1, noIndexCol2, invertedIndexCol2, noIndexCol1, "
-            + "rangeIndexCol3, textIndexCol1, mvRawCol1, jsonIndexCol1, invertedIndexCol3)", 4, 3
+        "PROJECT(invertedIndexCol1, invertedIndexCol2, invertedIndexCol3, jsonIndexCol1, mvNoIndexCol1"
+            + ", mvRawCol1, noIndexCol1, noIndexCol2, noIndexCol3, noIndexCol4, rangeIndexCol1"
+            + ", rangeIndexCol2, rangeIndexCol3, rawCol1, sortedIndexCol1, textIndexCol1)", 4, 3
     });
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
@@ -712,7 +712,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2, sortedIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(sortedIndexCol1, noIndexCol2, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, sortedIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
@@ -728,7 +728,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2)", 3, 2});
-    result2.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_AND", 6, 5});
     result2.add(new Object[]{
@@ -834,7 +834,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2, sortedIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(sortedIndexCol1, noIndexCol2, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, sortedIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
@@ -850,7 +850,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2)", 3, 2});
-    result2.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_AND", 6, 5});
     result2.add(new Object[]{
@@ -969,7 +969,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_AND", 6, 5});
     result1.add(new Object[]{
@@ -994,7 +994,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
-    result2.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_OR", 6, 5});
     result2.add(new Object[]{
@@ -1053,14 +1053,14 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_EMPTY", 6, 5});
     result1.add(new Object[]{
         "PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_AND", 6, 5});
     result1.add(new Object[]{
@@ -1084,7 +1084,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
-    result2.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_OR", 6, 5});
     result2.add(new Object[]{
@@ -1100,7 +1100,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
-    result2.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_OR", 6, 5});
     result2.add(new Object[]{
@@ -1166,7 +1166,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(rangeIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_OR", 6, 5});
     result1.add(new Object[]{"FILTER_AND", 7, 6});
@@ -1199,7 +1199,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(rangeIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_OR", 6, 5});
     result1.add(new Object[]{"FILTER_AND", 7, 6});
@@ -1231,7 +1231,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{
         "GROUP_BY(groupKeys:noIndexCol1, noIndexCol2, aggregations:max(noIndexCol2), min(noIndexCol3))", 3, 2
     });
-    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{
         "FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match(textIndexCol1,'foo'))", 6, 5
@@ -1251,7 +1251,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{
         "GROUP_BY(groupKeys:noIndexCol1, noIndexCol2, aggregations:max(noIndexCol2), min(noIndexCol3))", 3, 2
     });
-    result2.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{
         "FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match(textIndexCol1,'foo'))", 6, 5
@@ -1274,7 +1274,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{
         "GROUP_BY(groupKeys:noIndexCol1, noIndexCol2, aggregations:max(noIndexCol2), min(noIndexCol3))", 3, 2
     });
-    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{
         "FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match(textIndexCol1,'foo'))", 6, 5
@@ -1293,7 +1293,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{
         "GROUP_BY(groupKeys:noIndexCol1, noIndexCol2, aggregations:max(noIndexCol2), min(noIndexCol3))", 3, 2
     });
-    result2.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{
         "FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match(textIndexCol1,'foo'))", 6, 5
@@ -1389,7 +1389,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1 = '1.5')", 6, 5
@@ -1409,7 +1409,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_OR", 6, 5});
     result2.add(new Object[]{
@@ -1430,7 +1430,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol2)", 3, 2});
-    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, invertedIndexCol2)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol2, noIndexCol1)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{"FILTER_OR", 6, 5});
     result3.add(new Object[]{
@@ -1474,7 +1474,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1 = '1.5')", 6, 5
@@ -1483,14 +1483,14 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     result1.add(new Object[]{
         "PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_EMPTY", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
@@ -1507,7 +1507,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_OR", 6, 5});
     result2.add(new Object[]{
@@ -1520,7 +1520,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1 = '1.1')", 6, 5
@@ -1529,7 +1529,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_EMPTY", 6, 5});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
@@ -1544,7 +1544,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol2)", 3, 2});
-    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, invertedIndexCol2)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol2, noIndexCol1)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{"FILTER_OR", 6, 5});
     result3.add(new Object[]{
@@ -1595,7 +1595,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_EMPTY", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
@@ -1613,7 +1613,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_AND", 6, 5});
     result2.add(new Object[]{
@@ -1634,7 +1634,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol2)", 3, 2});
-    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, invertedIndexCol2)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol2, noIndexCol1)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{"FILTER_AND", 6, 5});
     result3.add(new Object[]{
@@ -1680,7 +1680,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_EMPTY", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
@@ -1697,7 +1697,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_AND", 6, 5});
     result2.add(new Object[]{
@@ -1710,7 +1710,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
-    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
     result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_EMPTY", 6, 5});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
@@ -1725,7 +1725,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
     });
     result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol2)", 3, 2});
-    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, invertedIndexCol2)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, invertedIndexCol2, noIndexCol1)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{"FILTER_AND", 6, 5});
     result3.add(new Object[]{
@@ -1798,7 +1798,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result3.add(
         new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2))", 3, 2});
-    result3.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
@@ -1819,7 +1819,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result4.add(
         new Object[]{"TRANSFORM(add(div(noIndexCol1,noIndexCol2),noIndexCol3), add(noIndexCol1,noIndexCol2))", 4, 3});
-    result4.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 5, 4});
     result4.add(new Object[]{"DOC_ID_SET", 6, 5});
     result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
@@ -1912,7 +1912,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result3.add(
         new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2))", 3, 2});
-    result3.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
@@ -1933,7 +1933,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result4.add(
         new Object[]{"TRANSFORM(add(div(noIndexCol1,noIndexCol2),noIndexCol3), add(noIndexCol1,noIndexCol2))", 4, 3});
-    result4.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 5, 4});
     result4.add(new Object[]{"DOC_ID_SET", 6, 5});
     result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
@@ -1957,7 +1957,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "GROUP_BY(groupKeys:noIndexCol2, aggregations:sum(add(noIndexCol1,noIndexCol2)), min(noIndexCol3))", 3, 2
     });
     result1.add(new Object[]{"TRANSFORM(add(noIndexCol1,noIndexCol2), noIndexCol2, noIndexCol3)", 4, 3});
-    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 5, 4});
     result1.add(new Object[]{"DOC_ID_SET", 6, 5});
     result1.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 < '3')", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
@@ -1984,7 +1984,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "GROUP_BY(groupKeys:noIndexCol2, aggregations:sum(add(noIndexCol1,noIndexCol2)), min(noIndexCol3))", 3, 2
     });
     result1.add(new Object[]{"TRANSFORM(add(noIndexCol1,noIndexCol2), noIndexCol2, noIndexCol3)", 4, 3});
-    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 5, 4});
     result1.add(new Object[]{"DOC_ID_SET", 6, 5});
     result1.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 < '3')", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
@@ -2043,7 +2043,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result3.add(
         new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3))", 3, 2});
-    result3.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1 = '1.1')", 6, 5
@@ -2230,7 +2230,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result3.add(
         new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3))", 3, 2});
-    result3.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{"FILTER_EMPTY", 6, 5});
     result3.add(new Object[]{
@@ -2238,7 +2238,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result3.add(
         new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3))", 3, 2});
-    result3.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1 = '1.1')", 6, 5
@@ -2409,7 +2409,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{
         "GROUP_BY(groupKeys:noIndexCol1, aggregations:max(noIndexCol2), min(noIndexCol3))", 3, 2
     });
-    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')", 6, 5
@@ -2431,7 +2431,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{
         "GROUP_BY(groupKeys:noIndexCol1, aggregations:max(noIndexCol2), min(noIndexCol3))", 3, 2
     });
-    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')", 6, 5
@@ -2507,7 +2507,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result.add(new Object[]{
         "GROUP_BY(groupKeys:noIndexCol3, aggregations:max(noIndexCol1), min(noIndexCol2))", 3, 2
     });
-    result.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result.add(new Object[]{"DOC_ID_SET", 5, 4});
     result.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')", 6, 5
@@ -2531,7 +2531,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result.add(new Object[]{
         "GROUP_BY(groupKeys:noIndexCol3, aggregations:max(noIndexCol1), min(noIndexCol2))", 3, 2
     });
-    result.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result.add(new Object[]{"PROJECT(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
     result.add(new Object[]{"DOC_ID_SET", 5, 4});
     result.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')", 6, 5

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pinot.queries;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -132,10 +134,13 @@ public class QueriesTestUtils {
 
   private static void validateRows(List<Object[]> actual, List<Object[]> expected) {
     assertEquals(actual.size(), expected.size());
+    List<Object> actualObjects = new ArrayList<>();
+    List<Object> expectedObjects = new ArrayList<>();
     for (int i = 0; i < actual.size(); i++) {
-      // Generic assertEquals delegates to assertArrayEquals, which can test for equality of array values in rows.
-      assertEquals((Object) actual.get(i), (Object) expected.get(i));
+      actualObjects.add(actual.get(i));
+      expectedObjects.add(expected.get(i));
     }
+    CollectionUtils.isEqualCollection(actualObjects, expectedObjects);
   }
 
   public static void testInterSegmentsResult(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,

--- a/pom.xml
+++ b/pom.xml
@@ -1468,6 +1468,7 @@
         -->
         <configuration>
           <testFailureIgnore>false</testFailureIgnore>
+          <argLine>-Dlog4j.configuration=</argLine>
           <!-- Excludes integration tests when unit tests are run. -->
           <excludes>
             <exclude>**/*IT.java</exclude>


### PR DESCRIPTION
## Test Case Information
Open Source Project - [pinot](https://github.com/AtharvChandratre/pinot)
Module - `pinot-core`
Test Case - `org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnsVariationsOfOrOperators`

## Setup Instructions

- [ ] Clone the repo - `git clone https://github.com/AtharvChandratre/pinot.git`
- [ ] Go into that folder - `cd pinot`
- [ ] Switch to the fix-flaky branch - `git switch fix-flaky`
- [ ]  Compile the test module - `mvn install -pl pinot-core -am -DskipTests`
- [ ] Check if the unit test is passing - `mvn -pl pinot-core test -Dtest=org.apache.pinot.queries.ExplainPlanQueriesTest#testSelectColumnsVariationsOfOrOperators`
- [ ] Check if the test is failing using NonDex - `mvn -pl pinot-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.pinot.queries.ExplainPlanQueriesTest#testSelectColumnsVariationsOfOrOperators`

## My Results

1. Able to fork and clone the repo
2. Able to compile the test module
3. Unit test is passing
4. Test is Failing using NonDex
5. Was able to resolve the flakiness of the test (NonDex passing with -DnondexRuns=100)
6. Was able to resolve another flaky test for extra credit.

## Background
Whenever a user creates a database query, the pinot-core library creates a plan for executing it. So when a user asks for an explanation of the plan of the query, the framework creates a "dataSourceMap" that contains the steps it would follow for said query execution. 

## Test Description
The test `ExplainPlanQueriesTest.testSelectColumnsVariationsOfOrOperators` checks to see if that functionality is working for sample queries using the "OR" SQL operator. However, the function was not returning a deterministic String.

## Debugging Analysis
On performing a thorough analysis of the codebase, the reason for this was determined to be because:
The `toExplainString` in `ProjectionOperator.java` that converts the plan to a string was doing dataSourceMap.keySet() to get the column names and then appending them one after the other to the final plan String to be returned. 

An example of this is a query like "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol2 FROM testTable WHERE ...". Here, the three columns being selected are stored in the map. So when NonDex was running, it would shuffle the order in which they were being retrieved from the map. Because of this, the test is flaky, which makes complete sense.

## Flakiness Resolution
This was the flaky part, as .keySet() does not guarantee order. Therefore, sorting these columns (aka the keySet) before building the string to be returned resolved the flakiness. The code diff in `ProjectionOperator.java` will be able to best explain the fix.

## Reasoning for Each File Changed

1. `ExplainPlanQueriesTest.java` - Changed all the tests that were flaky test expected values wherever the projection operator is being used. For example, you can see that the changes are only on the lines which begin with "PROJECT". This is because this was the only operator that was having an issue with determinism. All the other SQL operators use a list under the hood, whereas PROJECT uses a Map.
2. `ProjectionOperator.java` - The file where the fix was done. This was done by sorting the keys of the dataSourceMap. More information is in the Flakiness Resolution section above.
3. `QueriesTestUtils.java` - Modified `validateRows` as it was expecting a deterministic order in which the rows would be coming in from the ResultTable. So instead of comparing each one in the order in which it came in (as it was being done previously), now we are using the `CollectionUtils.isEqualCollection` instead to check if the returned rows are correct. Note - I did check if the order matters here, and it doesn't because pinot basically constructs a tree under the hood in order to extract the plan. In the tests, you can see that the expected output contains two numbers. The first number is the order number with which it will be executed, and the second number is the number of its parent. This way, order is determined on the spot when other functions are called, regardless of the order in which the rows are stored in the ResultTable.
4. `pom.xml` - This was changed to make pinot run locally on my laptop. For some reason, NonDex would give me a "Corrupted STDOUT by directly writing to native stream in forked JVM 1" error whenever I ran it without this line locally. This was discussed with @zzjas. This file change would not be a part of the actual PR if I were contributing it to the real repo.

# Extra Credit
Apart from the test mentioned above, a few other tests were also corrected, as they were flaky. The flakiness of the following tests was remedied. These are all tests in `pr-data.csv`.

1. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelect
6. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregate
7. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterGroupBy
8. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterGroupByVerbose
9. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterIndex
10. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterIndexGroupBy
11. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterIndexGroupByHaving
12. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterIndexGroupByHavingVerbose
13. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterIndexGroupByVerbose
14. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterIndexVerbose
15. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterOnTextIndexColumn
16. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterOnTextIndexColumnVerbose
17. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateVerbose
18. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnsUsingFilter
19. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnsUsingFilterOnInvertedIndexColumn
20. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnsUsingFilterOnInvertedIndexColumnVerbose
21. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnsUsingFilterVerbose
22. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnsVariationsOfAndOperators
23. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnsVariationsOfAndOperatorsVerbose
24. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnsVariationsOfOrOperators
25. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnsVariationsOfOrOperatorsVerbose
26. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnUsingFilterOnRangeIndexColumn
27. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectColumnUsingFilterOnRangeIndexColumnVerbose
28. org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectVerbose

This is because the root cause of all of these was the same issue. Among these, `org.apache.pinot.queries.ExplainPlanQueriesTest.testSelectAggregateUsingFilterOnTextIndexColumn` was a part of my 10 tests given for MP1.
